### PR TITLE
Username and room input boxes now use floating labels.

### DIFF
--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -58,25 +58,50 @@
     border-radius: 5px;
     padding: 0px 20px;
     margin: 20px;
-    width: 230px;
+    width: 330px;
   }
   
   .form-field {
     margin: 20px 0;
-  }
-  
-  .form-field > * {
-    width: 100%;
+    position: relative;
   }
   
   .form-field label {
-    display: block;
     margin-bottom: 7px;
+    position: absolute;
+    top: 10px;
+    left: 10px;
+    pointer-events: none;
+    transition: 0.2s ease all;
+    -moz-transition: 0.2s ease all;
+    -webkit-transition:0.2s ease all;
   }
   
   .form-field input, .form-field select {
     border: 1px solid #e1e1e1;
     padding: 10px;
+    width: 100%;    
+  }
+
+  .form-field input:focus {
+    outline: none;
+    transition: 0.2s ease all;
+    -moz-transition: 0.2s ease all;
+    -webkit-transition:0.2s ease all;
+  }
+
+  .form-field input:focus ~ label, input:valid ~ label  {
+    top: -15px;
+    left: 1px;
+    font-size: 12px;
+  }
+
+  input:valid {
+    border: 1px solid green;
+  }
+
+  input:valid ~ label {
+    color: green;
   }
   
   .chat {

--- a/public/index.html
+++ b/public/index.html
@@ -13,12 +13,12 @@
                     <h3>Join a chat</h3>
                 </div>
                 <div class="form-field">
+                    <input type="text" name="name" required />
                     <label>Display name</label>
-                    <input type="text" name="name" autofocus />
                 </div>
                 <div class="form-field">
+                    <input type="text" name="room" required />
                     <label>Room name</label>
-                    <input type="text" name="room" />
                 </div>
                 <div class="form-field">
                     <button type="submit">Join</button>


### PR DESCRIPTION
<img width="429" alt="screen shot 2017-10-21 at 20 46 49" src="https://user-images.githubusercontent.com/3789875/31855756-ff3df988-b6a0-11e7-818d-abfd5e3d29bb.png">

'Join a chat' box is now a little wider and the labels now float over the input box on focus.